### PR TITLE
Marker bug fix.

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -14,7 +14,8 @@ angular.module('citizen-engagement.controllers', ['citizen-engagement.constants'
                 tileLayer: mapboxTileLayer
             };
 
-            $scope.mapMarkers = [];
+            var markerVersion = 1;
+            $scope.mapMarkers = {};
 
             $scope.mapCenter = {
                 lat: 46.381907,
@@ -38,7 +39,7 @@ angular.module('citizen-engagement.controllers', ['citizen-engagement.constants'
             issueList.success(function (issues) {
                 angular.forEach(issues, function (issue) {
                     //console.log(issue.description)
-                    $scope.mapMarkers.push({
+                    $scope.mapMarkers[markerVersion + ':' + issue.id] = {
                         lat: issue.lat,
                         lng: issue.lng,
                         message: '<p>{{issue.description}}</p><img ng-src="{{issue.imageUrl}}" fallback-src="img/default.png" width="200px" /><a class="button icon-right ion-chevron-right button-calm" ng-controller="IssueController" ng-click="issueDetails(issue.id)">Details</a>',
@@ -47,7 +48,7 @@ angular.module('citizen-engagement.controllers', ['citizen-engagement.constants'
                             scope.issue = issue;
                             return scope;
                         }
-                    });
+                    };
                 });
                 $ionicLoading.hide();
             });
@@ -57,10 +58,12 @@ angular.module('citizen-engagement.controllers', ['citizen-engagement.constants'
             };
 
             $scope.$on("issueFilterEvent", function (event, issues) {
+                markerVersion++;
+                $scope.mapMarkers = {};
 //                console.log("IssueFilterEvent")
                 angular.forEach(issues, function (issue) {
 
-                    $scope.mapMarkers.push({
+                    $scope.mapMarkers[markerVersion + ':' + issue.id] = {
                         lat: issue.lat,
                         lng: issue.lng,
                         message: '<p>{{issue.description}}</p><img ng-src="{{issue.imageUrl}}" fallback-src="img/default.png" width="200px" /><a class="button icon-right ion-chevron-right button-calm" ng-controller="IssueController" ng-click="issueDetails(issue.id)">Details</a>',
@@ -69,7 +72,7 @@ angular.module('citizen-engagement.controllers', ['citizen-engagement.constants'
                             scope.issue = issue;
                             return scope;
                         }
-                    });
+                    };
                 });
             })
         })


### PR DESCRIPTION
Le problème du template des marqueurs est sûrement dû à un bug dans la directive angular leaflet. En lisant leur code source, j'ai trouvé comment contourner le problème. Il faut utiliser un objet de marqueurs nommés au lieu d'un tableau, et il faut qu'à chaque fois que les marqueurs changent, leur nom change aussi.

C'est ce que j'ai fait dans cette PR. Je commence par déclarer une variable qui servira à différencier les marqueurs à chaque fois qu'on les recrée, puis je crée un objet de marqueurs:

```
var markerVersion = 1;
$scope.mapMarkers = {};
```

Les marqueurs sont ensuite ajoutés avec un nom (qui contient la version):

```
$scope.mapMarkers[markerVersion + ':' + issue.id] = { ... };
```

Puis, lors du `issueFilterEvent`, j'incrémente la version et je recrée les marqueurs:

```
markerVersion++;
$scope.mapMarkers = {};
angular.forEach(issues, function(issue) {
  $scope.mapMarkers[markerVersion + ':' + issue.id] = { ... }
}
```

Note que ça élimine le problème du template, mais ça introduit un nouveau problème. Si tu dé-commente ton log:

```
// console.log("IssueFilterEvent")
```

Tu constateras que cet événement est lancé trop souvent.

La raison est que tu utilise le même contrôleur que dans le menu, `IssueController`, dans le template du marqueur:

```
<a class="..." ng-controller="IssueController" ng-click="issueDetails(issue.id)">Details</a>
```

C'est une très mauvaise idée. Ça veut dire qu'à chaque fois que tu clique sur un marqueur, il va recréer une instance de ce contrôleur, et donc refaire un `getIssues` et recréer tous les marqueurs.

Il faut que tu crée un contrôleur séparé, genre `IssueMarkerController`, avec juste la méthode `issueDetails`.
